### PR TITLE
Add node-sass and postcss-cli as dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   "homepage": "https://github.com/mozilla/mozfest-event-app#readme",
   "dependencies": {
     "autoprefixer": "^6.5.0",
-    "postcss": "^5.2.4"
+    "node-sass": "^3.10.1",
+    "postcss": "^5.2.4",
+    "postcss-cli": "^2.6.0"
   },
   "devDependencies": {
     "chokidar": "^1.6.0",


### PR DESCRIPTION
Running ```npm start``` after ```npm install``` exits with the following two errors:

```
npm ERR! Please include the following file with any support request:
npm sh: node-sass: command not found

sh: postcss: command not found
```

This PR adds both modules as dev dependency so they get installed.